### PR TITLE
Couple JS/CSS fixes

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,7 +4,7 @@ module.exports = {
     ...(process.env.NODE_ENV === "production"
       ? [
           require("@fullhuman/postcss-purgecss")({
-            content: ["./.11ty-vite/**/*.html"],
+            content: ["./.11ty-vite/**/*.html", "./.11ty-vite/**/*.js"],
             safelist: ["usa-js-loading"],
             extractors: [
               {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,12 @@
 import "@uswds/uswds/css/uswds.min.css"
 import { accordion, banner, navigation } from "@uswds/uswds/js"
+
+// This is part of the "uswds-init" machinery to handle failure to load JS
+// gracefully. Normally uswds-core/src/js/start.js would do this for us, but
+// this file only gets included in bundles - there's no way to individually
+// include it.
+window.uswdsPresent = true
+
 accordion.on()
 banner.on()
 navigation.on()


### PR DESCRIPTION
## assets: couple JS/CSS fixes

## Problem

The menu button on mobile doesn't work (#23), and the "here's how you know" on the banner doesn't either.

## Solution

Two separate fixes for the two issues - lumped into one PR because they're both tiny:

* Configure purgeCSS to detect classes used in JS, not just HTML.
* Manually set `window.uswdsPresent = true`, because the piece that's suppose to do that isn't accessible as an ES module.

## Test Plan

Manually tested - it works!
