### PR TITLE
Produce code.json.

### DIFF
--- a/site/_data/repos.js
+++ b/site/_data/repos.js
@@ -33,6 +33,23 @@ async function reposForOrg(org) {
                 isArchived
                 isFork
                 isEmpty
+                licenseInfo {
+                  spdxId
+                }
+                repositoryTopics(first: 100) {
+                  nodes {
+                    topic {
+                      name
+                    }
+                  }
+                }
+                languages(first: 100) {
+                  nodes {
+                    name
+                  }
+                }
+                createdAt
+                pushedAt
               }
               pageInfo {
                 endCursor
@@ -252,8 +269,8 @@ const manualOverrides = {
       "Bonnie is a software tool that allows electronic clinical quality measure (eCQM) developers to test and verify the behavior of their eCQM logic.",
   },
   "projectcypress/cypress": {
-    category: "tools"
-  }
+    category: "tools",
+  },
 }
 
 module.exports = async () => {

--- a/site/codejson.11ty.js
+++ b/site/codejson.11ty.js
@@ -1,0 +1,54 @@
+class CodeJson {
+  data() {
+    return {
+      permalink: "code.json",
+    }
+  }
+
+  render({ repos }) {
+    return JSON.stringify({
+      version: "2.0.0",
+      measurementType: {},
+      agency: "HHS",
+      releases: repos.repos.map((repo) => ({
+        name: repo.name,
+        organization: "CMS",
+        description: repo.description || "",
+        permissions: {
+          usageType: "openSource",
+          licenses:
+            repo.licenseInfo?.spdxId && repo.licenseInfo.spdxId != "NOASSERTION"
+              ? [{ name: repo.licenseInfo.spdxId }]
+              : null,
+        },
+        tags: (repo.category ? [repo.category] : []).concat(
+          repo.repositoryTopics.nodes.map((node) => node.topic.name)
+        ),
+        contact: { email: "opensource@cms.hhs.gov" },
+        vcs: "git",
+        repositoryURL: `https://github.com/${repo.owner.login}/${repo.name}.git`,
+        homepageURL:
+          repo.homepageUrl && repo.homepageUrl != ""
+            ? repo.homepageUrl
+            : undefined,
+        langauges: repo.languages.nodes.map((x) => x.name),
+        // supposedly a required field; most others seem to just be reporting 0 here
+        // ideally we would be making a calculation from lines of code
+        laborHours: 0.0,
+        relatedCode:
+          repo.otherRepos &&
+          repo.otherRepos.map((other) => ({
+            name: other,
+            URL: `https://github.com/${other}`,
+            isGovernmentRepo: true,
+          })),
+        date: {
+          created: repo.createdAt,
+          lastModified: repo.pushedAt,
+        },
+      })),
+    })
+  }
+}
+
+module.exports = CodeJson


### PR DESCRIPTION
## Problem

HHS is required to produce a code inventory at https://www.hhs.gov/code.json. Currently, no CMS repos end up there.

## Solution

Start serving an inventory of CMS projects in code.json format https://dsacms.github.io/open/code.json, with the eventual goal to have these entries published as part of the HHS inventory.

## Test Plan

Manually verified that the output looks right, and validated it against the JSON Schema published for code.json. 