### PR TITLE
Add search box to projects page.

### DIFF
--- a/site/projects.liquid
+++ b/site/projects.liquid
@@ -1,11 +1,25 @@
 ---
 layout: base
 ---
+<script type="module" src="/assets/js/projects.js"></script>
 <div class="grid-container">
-  The Centers for Medicare and Medicaid Services develops or funds many open-source projects. Here are some of them:
+  <p>
+    The Centers for Medicare and Medicaid Services develops or funds many open-source projects. Here are some of them:
+  </p>
+  <div class="margin-bottom-2">
+    <label class="usa-label" for="filter-input">Filter</label>
+    <div class="usa-input-group width-full maxw-none">
+      <div class="usa-input-prefix" aria-hidden="true">
+        <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
+          <use xlink:href="/assets/img/sprite.svg#search"></use>
+        </svg>
+      </div>
+      <input class="usa-input" id="filter-input" name="filter-input">
+    </div>
+  </div>
   <ul class="usa-card-group">
     {% for repo in repos.repos %}
-      <li class="usa-card tablet:grid-col-6">
+      <li class="usa-card project-card tablet:grid-col-6">
         <div class="usa-card__container">
           <div class="usa-card__header">
             <h2 class="usa-card__heading">

--- a/site/projects.liquid
+++ b/site/projects.liquid
@@ -4,7 +4,8 @@ layout: base
 <script type="module" src="/assets/js/projects.js"></script>
 <div class="grid-container">
   <p>
-    The Centers for Medicare and Medicaid Services develops or funds many open-source projects. Here are some of them:
+    The Centers for Medicare and Medicaid Services develops or supports many open-source projects. Here are some of
+    them:
   </p>
   <div class="margin-bottom-2">
     <label class="usa-label" for="filter-input">Filter</label>

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -1,0 +1,9 @@
+const filterBox = document.getElementById("filter-input")
+filterBox.addEventListener("input", () => {
+  const query = filterBox.value.toLowerCase()
+  document.querySelectorAll(".project-card").forEach((card) => {
+    card.hidden = !(
+      query == "" || card.textContent.toLowerCase().includes(query)
+    )
+  })
+})


### PR DESCRIPTION
## Problem

It'd be nice to have an easy way to filter for projects matching a given keyword.

## Solution

Implement a search box with a bit of a JS.

Just plain JS, no frameworks, no jQuery - in all my years of web dev, I'm not sure I've ever done that! A little clunkier, maybe, but it feels nice.

UI-wise, I don't use the USWDS search component, as that assumes a search button; we don't need one here, we can filter as the user types. Instead, I did something custom (or, rather, using more basic USWDS components) to put a search con on the left side of the field, along with an old-fashioned label:

<img width="1380" alt="screenshot of the projects page, now with a search box (as described). The search box has a label (with the text 'filter') and a little magnifying glass icon inside the field." src="https://github.com/DSACMS/open/assets/4495750/c8182b01-1acb-4480-b638-f26eb474ca28">

## Test Plan

Tested manually.
