### PR TITLE
Add stale repos workflow

### DIFF
--- a/.github/workflows/stale_repos.yml
+++ b/.github/workflows/stale_repos.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: stale repo identifier
     runs-on: ubuntu-latest
+    permissions: write-all
 
     steps:
       - name: Checkout code

--- a/.github/workflows/stale_repos.yml
+++ b/.github/workflows/stale_repos.yml
@@ -1,0 +1,32 @@
+name: stale repo identifier
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "3 2 1 * *"
+  push:
+    branches:
+      - add-stale-repos-workflow
+
+jobs:
+  build:
+    name: stale repo identifier
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run stale_repos tool
+        uses: docker://ghcr.io/github/stale_repos:v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORGANIZATION: DSACMS
+          # ORGANIZATION: ${{ secrets.ORGANIZATION }}
+          INACTIVE_DAYS: 365
+
+      - name: Create issue
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Stale repository report
+          content-filepath: ./stale_repos.md

--- a/.github/workflows/stale_repos.yml
+++ b/.github/workflows/stale_repos.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run stale_repos tool
         uses: docker://ghcr.io/github/stale_repos:v1
@@ -27,7 +27,10 @@ jobs:
           INACTIVE_DAYS: 365
 
       - name: Create issue
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v5
         with:
           title: Stale repository report
           content-filepath: ./stale_repos.md
+          labels: |
+            report
+            automated issue

--- a/.github/workflows/stale_repos.yml
+++ b/.github/workflows/stale_repos.yml
@@ -3,10 +3,7 @@ name: stale repo identifier
 on:
   workflow_dispatch:
   schedule:
-    - cron: "3 2 1 * *"
-  push:
-    branches:
-      - add-stale-repos-workflow
+    - cron: "0 0 1 * *"
 
 jobs:
   build:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Add stale repos workflow

## Problem

Currently, there is no way to easily see which repos in the DSACMS org
are stale.

## Solution

This Github Action workflow automatically creates an issue in the `open`
repo with a list of stale repos in the DSACMS Github org. The workflow
is currently configured to run on the first day of every month, and is set
to recognize stale repos when they reach over one year without
any edits.

## Result

The automated issue it created is here: https://github.com/DSACMS/open/issues/41